### PR TITLE
Fixed bug in stack destructor

### DIFF
--- a/LinkedListStack/Stack.h
+++ b/LinkedListStack/Stack.h
@@ -10,7 +10,12 @@ public:
 	Stack() = default;
 
 	~Stack() {
-		delete e;
+		auto node_to_delete = e;
+		while(node_to_delete != nullptr) {
+			auto temp = node_to_delete->Previous;
+			delete node_to_delete;
+			node_to_delete = temp;
+		}
 		e = nullptr;
 	}
 


### PR DESCRIPTION
The stack destructor was only deleting the top element and not every element in the stack. The destructor now goes through every element and deletes them individually.